### PR TITLE
マイページの作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    root_path
+    mypage_path
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+  
+  def show
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -30,6 +30,8 @@
   <section>
     <% if user_signed_in? %>
       <p><%= current_user.name %>さん、ログイン中です</p>
+
+      <%= link_to "マイページ", mypage_path %>
       <%= button_to "ログアウト", destroy_user_session_path, method: :delete %>
     <% else %>
       <%= link_to "ログイン", new_user_session_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,17 @@
+<h1>マイページ</h1>
+
+<p><%= current_user.name %>さん、こんにちは。</p>
+
+<h2>レシピ</h2>
+
+<p>レシピ機能は後続issueで実装予定です。</p>
+
+<ul>
+  <li>
+    <%= link_to "登録情報を変更する", edit_user_registration_path %>
+  </li>
+
+  <li>
+    <%= button_to "ログアウト", destroy_user_session_path, method: :delete %>
+  </li>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'users/show'
   devise_for :users
   # get 'static_pages/top'
   # get 'static_pages/terms'
@@ -12,6 +13,6 @@ Rails.application.routes.draw do
   get "terms", to: "static_pages#terms"
   get "privacy", to: "static_pages#privacy"
 
-  # Devise導入後に有効になる想定
-  # devise_for :users
+  resource :mypage, only: [:show], controller: "users"
+
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 対応内容
- マイページ用ルーティングを追加
- UsersController#showを追加
- マイページビューを作成
- 未ログイン時はログイン画面へリダイレクト
- ログイン後の遷移先をマイページに変更

## 未対応
- レシピ作成ページへのリンク
- レシピ一覧ページへのリンク
- アカウント削除ページへのリンク

## 関連Issue
Refs #12